### PR TITLE
Fix to read coe files with commas terminating all but the the last line.

### DIFF
--- a/atg.py
+++ b/atg.py
@@ -196,7 +196,7 @@ class Application:
                 if line.isspace():
                     continue
                 vec = line.replace(";", "").strip()     # Remove any ';' chars
-                vec = line.replace(",", "").strip()     # Remove any ';' chars
+                vec = vec.replace(",", "").strip()      # Remove any ',' chars
                 if self.radix == 'hex':
                     pass
                 elif self.radix == 'bin':


### PR DESCRIPTION
When attempted to import a ``.coe`` file created by Vivado in the following format which used a comma on all but the last initialisation element, and a semicolon on the final element, then ``atg.py`` reported an error attempting the import (didn't keep a record of the error message):
```
; SG initialization file for a
; 32-bit wide
memory_initialization_radix = 2;
memory_initialization_vector =
00000000000010110000000100000000,
00000000000010110000001000000001,
00000000000010110000001100000010,
00000000000010110000010000000011,
00000000000010110000010100000100,
00000000000000000000011000000101,
00000000000010110000011100000110,
00000000000010110000100000000111,
00000000000010110000100100001000,
00000000000010100000101000001001,
00000000000000000000101100001010,
00000000000010110000110000001011,
00000000000000000000110100001100,
00000000000010110000111000001101,
00000000000010110000111100001110,
00000000000010100001000000001111,
00000000000010100001000100010000,
00000000000010110001001000010001,
00000000000010110001001100010010,
00000000000010110000000100000000,
00000000000010110000001000000001,
00000000000010110000001100000010,
00000000000010110000010000000011,
00000000000010110000010100000100,
00000000000000000000011000000101,
00000000000010110000011100000110,
00000000000010110000100000000111,
00000000000010110000100100001000,
00000000000010100000101000001001,
00000000000000000000101100001010,
00000000000010110000110000001011,
00000000000000000000110100001100;
```
The change allows either a comma or semicolon terminator on each element.